### PR TITLE
`12` feat: Redis Stream 구현 및 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce:lettuce-core'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/team6server/feature/auth/application/SignUpService.java
+++ b/src/main/java/com/example/team6server/feature/auth/application/SignUpService.java
@@ -5,7 +5,6 @@ import com.example.team6server.feature.auth.dto.response.SignUpResponse;
 import com.example.team6server.feature.user.dao.UserRepository;
 import com.example.team6server.feature.user.domain.User;
 import com.example.team6server.feature.user.event.UserRegisteredEvent;
-import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
 import com.example.team6server.infra.redis.stream.publisher.RedisStreamPublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -35,6 +34,7 @@ public class SignUpService {
 		User savedUser = userRepository.save(user);
 
 		publishUserRegisteredEvent(savedUser);
+
 		return SignUpResponse.of(savedUser.getId(), savedUser.getName(), savedUser.getEmail());
 	}
 
@@ -45,6 +45,6 @@ public class SignUpService {
 				.name(user.getName())
 				.build();
 
-		eventPublisher.publish(RedisStreamMessage.of(event));
+		eventPublisher.publishAfterCommit(event);
 	}
 }

--- a/src/main/java/com/example/team6server/feature/user/event/UserRegisteredEvent.java
+++ b/src/main/java/com/example/team6server/feature/user/event/UserRegisteredEvent.java
@@ -1,0 +1,20 @@
+package com.example.team6server.feature.user.event;
+
+import com.example.team6server.infra.redis.stream.event.RedisStreamEvent;
+import com.example.team6server.infra.redis.stream.event.RedisStreamEventType;
+import lombok.Builder;
+
+@Builder
+public record UserRegisteredEvent(
+		Long userId,
+		String email,
+		String name
+) implements RedisStreamEvent {
+
+	public static final String TYPE = RedisStreamEventType.USER_REGISTERED;
+
+	@Override
+	public String type() {
+		return TYPE;
+	}
+}

--- a/src/main/java/com/example/team6server/feature/user/event/UserRegisteredEventListener.java
+++ b/src/main/java/com/example/team6server/feature/user/event/UserRegisteredEventListener.java
@@ -1,0 +1,49 @@
+package com.example.team6server.feature.user.event;
+
+import com.example.team6server.infra.redis.stream.annotation.RedisStreamEventListener;
+import com.example.team6server.infra.redis.stream.handler.AbstractRedisStreamEventHandler;
+import com.example.team6server.infra.slack.SlackNotifier;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RedisStreamEventListener
+public class UserRegisteredEventListener extends AbstractRedisStreamEventHandler<UserRegisteredEvent> {
+
+	public static final String NEW_USER_WELCOME_MESSAGE = """
+			:star2: *새로운 회원 가입 소식!* :star2:
+			
+			- 이름: %s
+			- 이메일: `%s`
+			- 사용자 ID: `%d`
+			
+			:wave: 환영합니다!
+			""";
+	private final SlackNotifier slackNotifier;
+
+	public UserRegisteredEventListener(ObjectMapper objectMapper, SlackNotifier slackNotifier) {
+		super(objectMapper);
+		this.slackNotifier = slackNotifier;
+	}
+
+	@Override
+	public String getEventType() {
+		return UserRegisteredEvent.TYPE;
+	}
+
+	@Override
+	protected Class<UserRegisteredEvent> payloadType() {
+		return UserRegisteredEvent.class;
+	}
+
+	@Override
+	@Transactional
+	protected void onMessage(UserRegisteredEvent event) {
+		log.info("Processing user registration: userId={}, email={}", event.userId(), event.email());
+
+		slackNotifier.send(NEW_USER_WELCOME_MESSAGE.formatted(event.name(), event.email(), event.userId()));
+
+		log.info("User registration processed: userId={}", event.userId());
+	}
+}

--- a/src/main/java/com/example/team6server/feature/user/event/UserRegisteredEventListener.java
+++ b/src/main/java/com/example/team6server/feature/user/event/UserRegisteredEventListener.java
@@ -5,7 +5,6 @@ import com.example.team6server.infra.redis.stream.handler.AbstractRedisStreamEve
 import com.example.team6server.infra.slack.SlackNotifier;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RedisStreamEventListener
@@ -38,7 +37,6 @@ public class UserRegisteredEventListener extends AbstractRedisStreamEventHandler
 	}
 
 	@Override
-	@Transactional
 	protected void onMessage(UserRegisteredEvent event) {
 		log.info("Processing user registration: userId={}, email={}", event.userId(), event.email());
 

--- a/src/main/java/com/example/team6server/global/config/jackson/JacksonConfig.java
+++ b/src/main/java/com/example/team6server/global/config/jackson/JacksonConfig.java
@@ -1,0 +1,21 @@
+package com.example.team6server.global.config.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/example/team6server/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/example/team6server/global/config/redis/RedisConfig.java
@@ -1,6 +1,7 @@
 package com.example.team6server.global.config.redis;
 
 import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +15,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
 	@Bean
-	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory, ObjectMapper objectMapper) {
 		RedisTemplate<String, Object> template = new RedisTemplate<>();
 		template.setConnectionFactory(connectionFactory);
 
@@ -23,8 +24,8 @@ public class RedisConfig {
 		template.setHashKeySerializer(new StringRedisSerializer());
 
 		// Value는 JSON으로 직렬화
-		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-		template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+		template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
 
 		template.afterPropertiesSet();
 		return template;

--- a/src/main/java/com/example/team6server/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/example/team6server/global/config/redis/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.example.team6server.global.config.redis;
+
+import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableConfigurationProperties(RedisStreamProperties.class)
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		// Key는 String으로 직렬화
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+
+		// Value는 JSON으로 직렬화
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+		template.afterPropertiesSet();
+		return template;
+	}
+}

--- a/src/main/java/com/example/team6server/global/config/redis/stream/RedisStreamProperties.java
+++ b/src/main/java/com/example/team6server/global/config/redis/stream/RedisStreamProperties.java
@@ -1,0 +1,15 @@
+package com.example.team6server.global.config.redis.stream;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "redis.stream")
+public record RedisStreamProperties(
+		String key,
+		String group,
+		String consumerName,
+		boolean isCreateGroupIfMissing,
+		boolean isAutoStart,
+		int batchSize,
+		long pollTimeoutMs
+) {
+}

--- a/src/main/java/com/example/team6server/global/config/redis/stream/RedisStreamRecoveryConfig.java
+++ b/src/main/java/com/example/team6server/global/config/redis/stream/RedisStreamRecoveryConfig.java
@@ -1,0 +1,37 @@
+package com.example.team6server.global.config.redis.stream;
+
+import com.example.team6server.infra.redis.stream.recovery.RedisStreamRecovery;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+@EnableConfigurationProperties(RedisStreamRecoveryProperties.class)
+@ConditionalOnProperty(prefix = "redis.stream.recovery", name = "is-enabled", havingValue = "true")
+public class RedisStreamRecoveryConfig {
+
+	private final RedisStreamRecovery recovery;
+	private final RedisStreamRecoveryProperties props;
+
+	@Scheduled(fixedDelayString = "${redis.stream.recovery.interval-ms:5000}", initialDelayString = "${redis.stream.recovery.interval-ms:5000}")
+	public void runOnceSafely() {
+		if (!props.isEnabled()) return;
+
+		long minIdle = props.minIdleMs() > 0 ? props.minIdleMs() : 1_000L;
+		long max = props.maxMessages() > 0 ? props.maxMessages() : 50L;
+
+		try {
+			recovery.reprocessPending(minIdle, max);
+			log.debug("[Recovery] done. minIdleMs={}, maxMessages={}", minIdle, max);
+		} catch (Exception e) {
+			log.error("[Recovery] failed. minIdleMs={}, maxMessages={}", minIdle, max, e);
+		}
+	}
+}

--- a/src/main/java/com/example/team6server/global/config/redis/stream/RedisStreamRecoveryProperties.java
+++ b/src/main/java/com/example/team6server/global/config/redis/stream/RedisStreamRecoveryProperties.java
@@ -1,0 +1,13 @@
+package com.example.team6server.global.config.redis.stream;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "redis.stream.recovery")
+public record RedisStreamRecoveryProperties(
+		boolean isEnabled,
+		long intervalMs,
+		long minIdleMs,
+		long maxMessages
+) {
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/annotation/RedisStreamEventListener.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/annotation/RedisStreamEventListener.java
@@ -1,0 +1,14 @@
+package com.example.team6server.infra.redis.stream.annotation;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+public @interface RedisStreamEventListener {
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/consumer/RedisStreamConsumer.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/consumer/RedisStreamConsumer.java
@@ -1,0 +1,94 @@
+package com.example.team6server.infra.redis.stream.consumer;
+
+import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
+import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
+import com.example.team6server.infra.redis.stream.util.RedisStreamMessageMapper;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.stream.StreamListener;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.data.redis.stream.Subscription;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisStreamConsumer implements StreamListener<String, ObjectRecord<String, String>> {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisStreamProperties properties;
+	private final RedisStreamGroupManager groupManager;
+	private final RedisStreamMessageMapper mapper;
+	private final RedisStreamMessageProcessor processor;
+
+	private final AtomicBoolean initialized = new AtomicBoolean(false);
+	private volatile StreamMessageListenerContainer<String, ObjectRecord<String, String>> container;
+	private volatile Subscription subscription;
+
+	@PostConstruct
+	public void autoStart() {
+		if (properties.isAutoStart()) initialize();
+	}
+
+	public void initialize() {
+		if (!initialized.compareAndSet(false, true)) return;
+
+		groupManager.ensureGroup();
+
+		container = StreamMessageListenerContainer.create(
+				redisTemplate.getConnectionFactory(),
+				StreamMessageListenerContainer.StreamMessageListenerContainerOptions.builder()
+						.pollTimeout(Duration.ofMillis(properties.pollTimeoutMs()))
+						.targetType(String.class)
+						.build()
+		);
+
+		subscription = container.receive(
+				Consumer.from(properties.group(), properties.consumerName()),
+				StreamOffset.create(properties.key(), ReadOffset.lastConsumed()),
+				this
+		);
+
+		container.start();
+		log.info("Redis Stream Consumer started: key={}, group={}, consumer={}",
+				properties.key(), properties.group(), properties.consumerName());
+	}
+
+	@Override
+	public void onMessage(ObjectRecord<String, String> message) {
+		String recordId = message.getId().getValue();
+		try {
+			RedisStreamMessage parsed = mapper.mapToMessage(message.getValue());
+			if (parsed == null) {
+				log.warn("Skip empty message: id={}", recordId);
+				return;
+			}
+			processor.process(recordId, parsed);
+		} catch (Exception e) {
+			log.error("onMessage error: id={}", recordId, e);
+			// PEL 유지 → Recovery가 처리 / 필요시 재시도 로직 추가하기
+		}
+	}
+
+	@PreDestroy
+	public void destroy() {
+		if (!initialized.compareAndSet(true, false)) return;
+		try {
+			if (subscription != null) subscription.cancel();
+			if (container != null && container.isRunning()) container.stop();
+			log.info("Redis Stream Consumer stopped");
+		} catch (Exception e) {
+			log.error("Shutdown error", e);
+		}
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/consumer/RedisStreamConsumer.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/consumer/RedisStreamConsumer.java
@@ -71,6 +71,7 @@ public class RedisStreamConsumer implements StreamListener<String, ObjectRecord<
 			RedisStreamMessage parsed = mapper.mapToMessage(message.getValue());
 			if (parsed == null) {
 				log.warn("Skip empty message: id={}", recordId);
+				redisTemplate.opsForStream().acknowledge(properties.key(), properties.group(), recordId);
 				return;
 			}
 			processor.process(recordId, parsed);

--- a/src/main/java/com/example/team6server/infra/redis/stream/consumer/RedisStreamGroupManager.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/consumer/RedisStreamGroupManager.java
@@ -1,0 +1,74 @@
+package com.example.team6server.infra.redis.stream.consumer;
+
+import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.output.StatusOutput;
+import io.lettuce.core.protocol.CommandArgs;
+import io.lettuce.core.protocol.CommandKeyword;
+import io.lettuce.core.protocol.CommandType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisStreamGroupManager {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisStreamProperties properties;
+
+	public void ensureGroup() {
+		String streamKey = properties.key();
+		String groupName = properties.group();
+
+		try {
+			Boolean exists = redisTemplate.hasKey(streamKey);
+			if (Boolean.FALSE.equals(exists)) {
+				createStreamWithMkStream(streamKey, groupName);
+				return;
+			}
+			if (!isGroupExists(streamKey, groupName)) {
+				redisTemplate.opsForStream().createGroup(streamKey, ReadOffset.from("0"), groupName);
+				log.info("Consumer group created: {}", groupName);
+			}
+		} catch (Exception e) {
+			log.error("ensureGroup failed", e);
+			throw new IllegalStateException("Failed to ensure stream/group", e);
+		}
+	}
+
+	private boolean isGroupExists(String streamKey, String groupName) {
+		try {
+			return redisTemplate.opsForStream().groups(streamKey)
+					.stream().anyMatch(g -> groupName.equals(g.groupName()));
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private void createStreamWithMkStream(String streamKey, String groupName) {
+		try (RedisConnection connection = redisTemplate.getConnectionFactory().getConnection()) {
+			Object nativeConn = connection.getNativeConnection();
+			if (nativeConn instanceof RedisAsyncCommands<?, ?> commands) {
+				RedisAsyncCommands<String, String> async = (RedisAsyncCommands<String, String>) commands;
+				CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8)
+						.add(CommandKeyword.CREATE).add(streamKey).add(groupName).add("0").add("MKSTREAM");
+				RedisFuture<String> future = async.dispatch(CommandType.XGROUP, new StatusOutput<>(StringCodec.UTF8), args);
+				future.get(5, TimeUnit.SECONDS);
+				log.info("Stream+Group created with MKSTREAM: key={}, group={}", streamKey, groupName);
+			}
+		} catch (Exception e) {
+			log.error("MKSTREAM failed", e);
+			throw new IllegalStateException("MKSTREAM failed", e);
+		}
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/consumer/RedisStreamMessageProcessor.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/consumer/RedisStreamMessageProcessor.java
@@ -1,0 +1,45 @@
+package com.example.team6server.infra.redis.stream.consumer;
+
+import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
+import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
+import com.example.team6server.infra.redis.stream.handler.RedisStreamEventHandler;
+import com.example.team6server.infra.redis.stream.handler.RedisStreamEventHandlerRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisStreamMessageProcessor {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisStreamEventHandlerRegistry handlerRegistry;
+	private final RedisStreamProperties properties;
+
+	public void process(String recordId, RedisStreamMessage message) {
+		String type = message.getType();
+
+		if (!handlerRegistry.hasHandler(type)) {
+			log.warn("No handler for type={}", type);
+			this.ack(recordId);
+			return;
+		}
+
+		RedisStreamEventHandler handler = handlerRegistry.getHandler(type);
+		try {
+			log.debug("Dispatch to handler: type={}, handler={}", type, handler.getClass().getSimpleName());
+			handler.handle(message);
+			this.ack(recordId);
+		} catch (Exception e) {
+			log.error("Handler failed: type={}, id={}", type, recordId, e);
+			// ACK 하지 않음 → PEL 유지 → Recovery 가 재처리
+			throw e;
+		}
+	}
+
+	private void ack(String recordId) {
+		redisTemplate.opsForStream().acknowledge(properties.key(), properties.group(), recordId);
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/dto/RedisStreamMessage.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/dto/RedisStreamMessage.java
@@ -1,0 +1,37 @@
+package com.example.team6server.infra.redis.stream.dto;
+
+import com.example.team6server.infra.redis.stream.event.RedisStreamEvent;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RedisStreamMessage implements Serializable {
+	private String id;
+	private String type;
+	private Object payload;
+	private LocalDateTime timestamp;
+	private String source;
+
+	public static RedisStreamMessage of(RedisStreamEvent event) {
+		return RedisStreamMessage.builder()
+				.type(event.type())
+				.payload(event)
+				.timestamp(LocalDateTime.now())
+				.build();
+	}
+
+	public <T> T getPayloadAs(ObjectMapper om, Class<T> type) {
+		return om.convertValue(payload, type);
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/event/RedisStreamEvent.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/event/RedisStreamEvent.java
@@ -1,0 +1,9 @@
+package com.example.team6server.infra.redis.stream.event;
+
+public interface RedisStreamEvent {
+	String type();
+
+	default String id() {
+		return "";
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/event/RedisStreamEvent.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/event/RedisStreamEvent.java
@@ -1,6 +1,7 @@
 package com.example.team6server.infra.redis.stream.event;
 
 public interface RedisStreamEvent {
+
 	String type();
 
 	default String id() {

--- a/src/main/java/com/example/team6server/infra/redis/stream/event/RedisStreamEventType.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/event/RedisStreamEventType.java
@@ -1,0 +1,9 @@
+package com.example.team6server.infra.redis.stream.event;
+
+public final class RedisStreamEventType {
+
+	public static final String USER_REGISTERED = "USER_REGISTERED";
+
+	private RedisStreamEventType() {
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/handler/AbstractRedisStreamEventHandler.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/handler/AbstractRedisStreamEventHandler.java
@@ -1,0 +1,43 @@
+package com.example.team6server.infra.redis.stream.handler;
+
+import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
+import com.example.team6server.infra.redis.stream.event.RedisStreamEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class AbstractRedisStreamEventHandler<T extends RedisStreamEvent>
+		implements RedisStreamEventHandler {
+
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * 라우팅 키
+	 */
+	@Override
+	public abstract String getEventType();
+
+	/**
+	 * 변환 대상 타입
+	 */
+	protected abstract Class<T> payloadType();
+
+	/**
+	 * 비즈니스 로직
+	 */
+	protected abstract void onMessage(T event) throws Exception;
+
+	@Override
+	public void handle(RedisStreamMessage message) {
+		try {
+			T event = message.getPayloadAs(objectMapper, payloadType());
+			this.onMessage(event);
+		} catch (Exception e) {
+			log.error("Event handling failed. type={}, id={}", message.getType(), message.getId(), e);
+			throw new RuntimeException("Event handling failed", e);
+		}
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/handler/RedisStreamEventHandler.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/handler/RedisStreamEventHandler.java
@@ -1,0 +1,16 @@
+package com.example.team6server.infra.redis.stream.handler;
+
+import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
+
+public interface RedisStreamEventHandler {
+
+	/**
+	 * 처리할 수 있는 이벤트 타입을 반환
+	 */
+	String getEventType();
+
+	/**
+	 * 비즈니스 로직 처리
+	 */
+	void handle(RedisStreamMessage message);
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/handler/RedisStreamEventHandlerRegistry.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/handler/RedisStreamEventHandlerRegistry.java
@@ -1,0 +1,39 @@
+package com.example.team6server.infra.redis.stream.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class RedisStreamEventHandlerRegistry {
+
+	private final Map<String, RedisStreamEventHandler> handlerMap;
+
+	@Autowired
+	public RedisStreamEventHandlerRegistry(List<RedisStreamEventHandler> handlers) {
+		this.handlerMap = handlers.stream()
+				.collect(Collectors.toMap(
+						RedisStreamEventHandler::getEventType,
+						Function.identity(),
+						(existing, replacement) -> {
+							log.warn("Duplicate handler found for event type: {}. Using: {}",
+									existing.getEventType(), replacement.getClass().getSimpleName());
+							return replacement;
+						}
+				));
+	}
+
+	public RedisStreamEventHandler getHandler(String eventType) {
+		return handlerMap.get(eventType);
+	}
+
+	public boolean hasHandler(String eventType) {
+		return handlerMap.containsKey(eventType);
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/handler/RedisStreamEventHandlerRegistry.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/handler/RedisStreamEventHandlerRegistry.java
@@ -22,9 +22,11 @@ public class RedisStreamEventHandlerRegistry {
 						RedisStreamEventHandler::getEventType,
 						Function.identity(),
 						(existing, replacement) -> {
-							log.warn("Duplicate handler found for event type: {}. Using: {}",
-									existing.getEventType(), replacement.getClass().getSimpleName());
-							return replacement;
+							throw new IllegalStateException(String.format(
+									"Duplicate handler for event type '%s': %s vs %s",
+									existing.getEventType(),
+									existing.getClass().getName(),
+									replacement.getClass().getName()));
 						}
 				));
 	}

--- a/src/main/java/com/example/team6server/infra/redis/stream/publisher/RedisStreamPublisher.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/publisher/RedisStreamPublisher.java
@@ -1,51 +1,30 @@
 package com.example.team6server.infra.redis.stream.publisher;
 
-import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
 import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.stream.ObjectRecord;
+import com.example.team6server.infra.redis.stream.event.RedisStreamEvent;
 import org.springframework.data.redis.connection.stream.RecordId;
-import org.springframework.data.redis.connection.stream.StreamRecords;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Component;
 
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class RedisStreamPublisher {
+public interface RedisStreamPublisher {
 
-	private final RedisTemplate<String, Object> redisTemplate;
-	private final RedisStreamProperties properties;
-	private final ObjectMapper objectMapper;
+	/**
+	 * 이벤트를 즉시 발행
+	 */
+	RecordId publish(RedisStreamEvent event);
 
-	public RecordId publish(RedisStreamMessage message) {
-		return publish(properties.key(), message);
-	}
+	/**
+	 * 트랜잭션 커밋 후 이벤트 발행
+	 * 트랜잭션이 없는 경우 즉시 발행
+	 */
+	void publishAfterCommit(RedisStreamEvent event);
 
-	private RecordId publish(String streamKey, RedisStreamMessage message) {
-		try {
-			String jsonMessage = objectMapper.writeValueAsString(message);
+	/**
+	 * 메시지를 즉시 발행
+	 */
+	RecordId publish(RedisStreamMessage message);
 
-			ObjectRecord<String, String> record = StreamRecords.newRecord()
-					.ofObject(jsonMessage)
-					.withStreamKey(streamKey);
-
-			RecordId recordId = redisTemplate.opsForStream().add(record);
-
-			if (recordId == null) {
-				throw new RuntimeException("Failed to publish message to Redis Stream");
-			}
-
-			log.info("Published message: StreamKey={}, RecordId={}, Type={}",
-					streamKey, recordId.getValue(), message.getType());
-
-			return recordId;
-
-		} catch (Exception e) {
-			log.error("Error publishing message to Redis Stream", e);
-			throw new RuntimeException("Error publishing message to Redis Stream", e);
-		}
-	}
+	/**
+	 * 트랜잭션 커밋 후 메시지 발행
+	 * 트랜잭션이 없는 경우 즉시 발행
+	 */
+	void publishAfterCommit(RedisStreamMessage message);
 }

--- a/src/main/java/com/example/team6server/infra/redis/stream/publisher/RedisStreamPublisher.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/publisher/RedisStreamPublisher.java
@@ -1,0 +1,51 @@
+package com.example.team6server.infra.redis.stream.publisher;
+
+import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
+import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisStreamPublisher {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisStreamProperties properties;
+	private final ObjectMapper objectMapper;
+
+	public RecordId publish(RedisStreamMessage message) {
+		return publish(properties.key(), message);
+	}
+
+	private RecordId publish(String streamKey, RedisStreamMessage message) {
+		try {
+			String jsonMessage = objectMapper.writeValueAsString(message);
+
+			ObjectRecord<String, String> record = StreamRecords.newRecord()
+					.ofObject(jsonMessage)
+					.withStreamKey(streamKey);
+
+			RecordId recordId = redisTemplate.opsForStream().add(record);
+
+			if (recordId == null) {
+				throw new RuntimeException("Failed to publish message to Redis Stream");
+			}
+
+			log.info("Published message: StreamKey={}, RecordId={}, Type={}",
+					streamKey, recordId.getValue(), message.getType());
+
+			return recordId;
+
+		} catch (Exception e) {
+			log.error("Error publishing message to Redis Stream", e);
+			throw new RuntimeException("Error publishing message to Redis Stream", e);
+		}
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/publisher/RedisStreamPublisherImpl.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/publisher/RedisStreamPublisherImpl.java
@@ -1,0 +1,106 @@
+package com.example.team6server.infra.redis.stream.publisher;
+
+import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
+import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
+import com.example.team6server.infra.redis.stream.event.RedisStreamEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisStreamPublisherImpl implements RedisStreamPublisher {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisStreamProperties properties;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public RecordId publish(RedisStreamEvent event) {
+		return publish(RedisStreamMessage.of(event));
+	}
+
+	@Override
+	public void publishAfterCommit(RedisStreamEvent event) {
+		publishAfterCommit(RedisStreamMessage.of(event));
+	}
+
+	@Override
+	public RecordId publish(RedisStreamMessage message) {
+		return doPublish(properties.key(), message);
+	}
+
+	@Override
+	public void publishAfterCommit(RedisStreamMessage message) {
+		if (TransactionSynchronizationManager.isSynchronizationActive()) {
+			registerTransactionSynchronization(message);
+			log.debug("Message scheduled for publication after commit: type={}", message.getType());
+		} else {
+			log.debug("No active transaction, publishing message immediately: type={}", message.getType());
+			publish(message);
+		}
+	}
+
+	private void registerTransactionSynchronization(RedisStreamMessage message) {
+		TransactionSynchronizationManager.registerSynchronization(
+				getTransactionSynchronization(message)
+		);
+	}
+
+	@NotNull
+	private TransactionSynchronization getTransactionSynchronization(RedisStreamMessage message) {
+		return new TransactionSynchronization() {
+			@Override
+			public void afterCommit() {
+				try {
+					log.info("[AFTER_COMMIT] Publishing event: type={}, timestamp={}", message.getType(), System.currentTimeMillis());
+					publish(message);
+					log.debug("Message published after transaction commit: type={}", message.getType());
+				} catch (Exception e) {
+					log.error("Failed to publish message after commit: type={}", message.getType(), e);
+				}
+			}
+
+			@Override
+			public void afterCompletion(int status) {
+				if (status == STATUS_ROLLED_BACK) {
+					log.debug("Transaction rolled back, message not published: type={}", message.getType());
+				}
+			}
+		};
+	}
+
+	private RecordId doPublish(String streamKey, RedisStreamMessage message) {
+		try {
+			String jsonMessage = objectMapper.writeValueAsString(message);
+
+			ObjectRecord<String, String> record = StreamRecords.newRecord()
+					.ofObject(jsonMessage)
+					.withStreamKey(streamKey);
+
+			RecordId recordId = redisTemplate.opsForStream().add(record);
+
+			if (recordId == null) {
+				throw new RuntimeException("Failed to publish message to Redis Stream");
+			}
+
+			log.info("Published message: StreamKey={}, RecordId={}, Type={}",
+					streamKey, recordId.getValue(), message.getType());
+
+			return recordId;
+
+		} catch (Exception e) {
+			log.error("Error publishing message to Redis Stream", e);
+			throw new RuntimeException("Error publishing message to Redis Stream", e);
+		}
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/publisher/RedisStreamPublisherImpl.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/publisher/RedisStreamPublisherImpl.java
@@ -62,7 +62,6 @@ public class RedisStreamPublisherImpl implements RedisStreamPublisher {
 			@Override
 			public void afterCommit() {
 				try {
-					log.info("[AFTER_COMMIT] Publishing event: type={}, timestamp={}", message.getType(), System.currentTimeMillis());
 					publish(message);
 					log.debug("Message published after transaction commit: type={}", message.getType());
 				} catch (Exception e) {

--- a/src/main/java/com/example/team6server/infra/redis/stream/recovery/RedisStreamRecovery.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/recovery/RedisStreamRecovery.java
@@ -1,0 +1,88 @@
+package com.example.team6server.infra.redis.stream.recovery;
+
+import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
+import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisStreamRecovery {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final RedisStreamProperties properties;
+	private final ObjectMapper objectMapper;
+
+	public void reprocessPending(long minIdleMs, long count) {
+		PendingMessagesSummary summary = redisTemplate.opsForStream()
+				.pending(properties.key(), properties.group());
+
+		if (summary == null || summary.getTotalPendingMessages() == 0) {
+			return;
+		}
+
+		log.info("Pending messages: total={}, minId={}, maxId={}",
+				summary.getTotalPendingMessages(),
+				summary.minMessageId(),
+				summary.maxMessageId());
+
+		PendingMessages pending = redisTemplate.opsForStream().pending(
+				properties.key(),
+				properties.group(),
+				Range.unbounded(),
+				count
+		);
+
+		for (PendingMessage pm : pending) {
+			if (pm.getElapsedTimeSinceLastDelivery().toMillis() < minIdleMs) {
+				continue;
+			}
+
+			List<MapRecord<String, Object, Object>> claimed = redisTemplate.opsForStream().claim(
+					properties.key(),
+					properties.group(),
+					properties.consumerName(),
+					Duration.ofMillis(minIdleMs),
+					pm.getId()
+			);
+
+			for (MapRecord<String, Object, Object> record : claimed) {
+				try {
+					processRecord(record);
+					redisTemplate.opsForStream().acknowledge(
+							properties.key(),
+							properties.group(),
+							record.getId()
+					);
+				} catch (Exception e) {
+					log.error("Reprocess failed for message: {}", record.getId(), e);
+				}
+			}
+		}
+	}
+
+	private void processRecord(MapRecord<String, Object, Object> record) throws Exception {
+		Object payload = record.getValue().get("payload");
+		if (payload == null) return;
+
+		String jsonString = payload.toString();
+		if (jsonString.startsWith("\"") && jsonString.endsWith("\"")) {
+			jsonString = jsonString.substring(1, jsonString.length() - 1).replace("\\\"", "\"");
+		}
+
+		RedisStreamMessage message = objectMapper.readValue(jsonString, RedisStreamMessage.class);
+		log.info("Reprocessing message: Type={}, RecordId={}", message.getType(), record.getId());
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/util/RedisStreamMessageMapper.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/util/RedisStreamMessageMapper.java
@@ -1,0 +1,21 @@
+package com.example.team6server.infra.redis.stream.util;
+
+import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisStreamMessageMapper {
+
+	private final ObjectMapper objectMapper;
+
+	public RedisStreamMessage mapToMessage(String raw) throws Exception {
+		if (raw == null || raw.isEmpty()) return null;
+		if (raw.startsWith("\"") && raw.endsWith("\"")) {
+			raw = raw.substring(1, raw.length() - 1).replace("\\\"", "\"");
+		}
+		return objectMapper.readValue(raw, RedisStreamMessage.class);
+	}
+}

--- a/src/main/java/com/example/team6server/infra/redis/stream/util/RedisStreamMessageMapper.java
+++ b/src/main/java/com/example/team6server/infra/redis/stream/util/RedisStreamMessageMapper.java
@@ -12,10 +12,11 @@ public class RedisStreamMessageMapper {
 	private final ObjectMapper objectMapper;
 
 	public RedisStreamMessage mapToMessage(String raw) throws Exception {
-		if (raw == null || raw.isEmpty()) return null;
+		if (raw == null || raw.isBlank()) return null;
+		String payload = raw;
 		if (raw.startsWith("\"") && raw.endsWith("\"")) {
-			raw = raw.substring(1, raw.length() - 1).replace("\\\"", "\"");
+			payload = objectMapper.readValue(raw, String.class);
 		}
-		return objectMapper.readValue(raw, RedisStreamMessage.class);
+		return objectMapper.readValue(payload, RedisStreamMessage.class);
 	}
 }

--- a/src/test/java/com/example/team6server/global/redis/RedisStreamRecoveryTest.java
+++ b/src/test/java/com/example/team6server/global/redis/RedisStreamRecoveryTest.java
@@ -4,7 +4,7 @@ import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
 import com.example.team6server.global.service.ServiceTest;
 import com.example.team6server.infra.redis.stream.consumer.RedisStreamGroupManager;
 import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
-import com.example.team6server.infra.redis.stream.publisher.RedisStreamPublisher;
+import com.example.team6server.infra.redis.stream.publisher.RedisStreamPublisherImpl;
 import com.example.team6server.infra.redis.stream.recovery.RedisStreamRecovery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,7 +23,7 @@ public class RedisStreamRecoveryTest extends ServiceTest {
 	@Autowired
 	private RedisStreamRecovery recovery;
 	@Autowired
-	private RedisStreamPublisher publisher;
+	private RedisStreamPublisherImpl publisher;
 	@Autowired
 	private RedisStreamGroupManager groupManager;
 	@Autowired

--- a/src/test/java/com/example/team6server/global/redis/RedisStreamRecoveryTest.java
+++ b/src/test/java/com/example/team6server/global/redis/RedisStreamRecoveryTest.java
@@ -1,0 +1,157 @@
+package com.example.team6server.global.redis;
+
+import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
+import com.example.team6server.global.service.ServiceTest;
+import com.example.team6server.infra.redis.stream.consumer.RedisStreamGroupManager;
+import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
+import com.example.team6server.infra.redis.stream.publisher.RedisStreamPublisher;
+import com.example.team6server.infra.redis.stream.recovery.RedisStreamRecovery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.*;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RedisStreamRecoveryTest extends ServiceTest {
+
+	@Autowired
+	private RedisStreamRecovery recovery;
+	@Autowired
+	private RedisStreamPublisher publisher;
+	@Autowired
+	private RedisStreamGroupManager groupManager;
+	@Autowired
+	private RedisTemplate<String, Object> redisTemplate;
+	@Autowired
+	private RedisStreamProperties properties;
+
+	@BeforeEach
+	void setUp() {
+		cleanupStream();
+		groupManager.ensureGroup();
+	}
+
+	private void cleanupStream() {
+		try {
+			if (Boolean.TRUE.equals(redisTemplate.hasKey(properties.key()))) {
+				try {
+					redisTemplate.opsForStream().destroyGroup(properties.key(), properties.group());
+				} catch (Exception ignored) {
+				}
+				redisTemplate.delete(properties.key());
+			}
+		} catch (Exception ignored) {
+		}
+	}
+
+	@Test
+	@DisplayName("PEL에 있는 오래된 메시지를 재처리한다")
+	void testRecoveryProcess() throws InterruptedException {
+		// given - 메시지 발행 및 읽기 (ACK 하지 않음)
+		TestRedisStreamEvent event = new TestRedisStreamEvent("recovery-data");
+		RedisStreamMessage message = RedisStreamMessage.of(event);
+		RecordId recordId = publisher.publish(message);
+
+		List<MapRecord<String, Object, Object>> records = redisTemplate.opsForStream().read(
+				Consumer.from(properties.group(), "test-consumer"),
+				StreamReadOptions.empty().count(1),
+				StreamOffset.create(properties.key(), ReadOffset.lastConsumed())
+		);
+
+		assertFalse(records.isEmpty());
+		assertEquals(recordId.getValue(), records.get(0).getId().getValue());
+
+		PendingMessagesSummary beforeSummary = redisTemplate.opsForStream()
+				.pending(properties.key(), properties.group());
+		assertEquals(1L, beforeSummary.getTotalPendingMessages());
+
+		Thread.sleep(1500);
+
+		// when - Recovery 실행
+		recovery.reprocessPending(1000, 10);
+
+		// then - Recovery 후 상태 확인
+		Thread.sleep(500);
+		PendingMessages pendingAfter = redisTemplate.opsForStream().pending(
+				properties.key(),
+				Consumer.from(properties.group(), properties.consumerName()),
+				Range.unbounded(),
+				10L
+		);
+		assertTrue(pendingAfter.size() >= 0);
+	}
+
+	@Test
+	@DisplayName("여러 개의 PEL 메시지를 한 번에 재처리한다")
+	void testBatchRecovery() throws InterruptedException {
+		// given - 5개 메시지 발행 및 읽기 (ACK 하지 않음)
+		for (int i = 0; i < 5; i++) {
+			TestRedisStreamEvent event = new TestRedisStreamEvent("batch-data-" + i);
+			publisher.publish(RedisStreamMessage.of(event));
+		}
+		redisTemplate.opsForStream().read(
+				Consumer.from(properties.group(), "test-consumer"),
+				StreamReadOptions.empty().count(5),
+				StreamOffset.create(properties.key(), ReadOffset.lastConsumed())
+		);
+		PendingMessagesSummary beforeSummary = redisTemplate.opsForStream()
+				.pending(properties.key(), properties.group());
+		assertEquals(5L, beforeSummary.getTotalPendingMessages());
+		Thread.sleep(1500);
+
+		// when - Recovery 실행 (최대 3개씩 처리)
+		recovery.reprocessPending(1000, 3);
+
+		// then
+		Thread.sleep(500);
+		PendingMessagesSummary afterSummary = redisTemplate.opsForStream()
+				.pending(properties.key(), properties.group());
+		assertTrue(afterSummary.getTotalPendingMessages() <= 5);
+	}
+
+	@Test
+	@DisplayName("minIdleTime이 지나지 않은 메시지는 재처리하지 않는다")
+	void testMinIdleTimeRespected() {
+		// given - 메시지 발행 및 즉시 읽기
+		TestRedisStreamEvent event = new TestRedisStreamEvent("fresh-data");
+		publisher.publish(RedisStreamMessage.of(event));
+		redisTemplate.opsForStream().read(
+				Consumer.from(properties.group(), "test-consumer"),
+				StreamReadOptions.empty().count(1),
+				StreamOffset.create(properties.key(), ReadOffset.lastConsumed())
+		);
+
+		// when - 긴 minIdleTime으로 Recovery 실행
+		recovery.reprocessPending(5000, 10);
+
+		// then - 메시지는 여전히 원래 consumer에게 할당되어 있어야 함
+		PendingMessages pending = redisTemplate.opsForStream().pending(
+				properties.key(),
+				Consumer.from(properties.group(), "test-consumer"),
+				Range.unbounded(),
+				10L
+		);
+		assertEquals(1, pending.size());
+		assertEquals("test-consumer", pending.get(0).getConsumerName());
+	}
+
+	@Test
+	@DisplayName("PEL이 비어있을 때 Recovery는 아무 작업도 하지 않는다")
+	void testRecoveryWithEmptyPEL() {
+		// given - PEL이 비어있는 상태
+
+		// when
+		recovery.reprocessPending(1000, 10);
+
+		// then - 예외가 발생하지 않아야 함
+		PendingMessagesSummary summary = redisTemplate.opsForStream()
+				.pending(properties.key(), properties.group());
+		assertEquals(0L, summary.getTotalPendingMessages());
+	}
+}

--- a/src/test/java/com/example/team6server/global/redis/RedisStreamTest.java
+++ b/src/test/java/com/example/team6server/global/redis/RedisStreamTest.java
@@ -1,0 +1,313 @@
+package com.example.team6server.global.redis;
+
+import com.example.team6server.global.config.redis.stream.RedisStreamProperties;
+import com.example.team6server.global.service.ServiceTest;
+import com.example.team6server.infra.redis.stream.consumer.RedisStreamConsumer;
+import com.example.team6server.infra.redis.stream.consumer.RedisStreamGroupManager;
+import com.example.team6server.infra.redis.stream.dto.RedisStreamMessage;
+import com.example.team6server.infra.redis.stream.event.RedisStreamEventType;
+import com.example.team6server.infra.redis.stream.handler.RedisStreamEventHandlerRegistry;
+import com.example.team6server.infra.redis.stream.publisher.RedisStreamPublisher;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.*;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class RedisStreamTest extends ServiceTest {
+
+	@Autowired
+	private RedisStreamPublisher publisher;
+	@Autowired
+	private RedisStreamConsumer consumer;
+	@Autowired
+	private RedisStreamGroupManager groupManager;
+	@Autowired
+	private RedisStreamEventHandlerRegistry handlerRegistry;
+	@Autowired
+	private RedisTemplate<String, Object> redisTemplate;
+	@Autowired
+	private RedisStreamProperties properties;
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUp() {
+		cleanupStream();
+	}
+
+	@AfterEach
+	void tearDown() {
+		stopConsumerSafely();
+	}
+
+	private void cleanupStream() {
+		try {
+			if (Boolean.TRUE.equals(redisTemplate.hasKey(properties.key()))) {
+				try {
+					redisTemplate.opsForStream().destroyGroup(properties.key(), properties.group());
+				} catch (Exception ignored) {
+				}
+				redisTemplate.delete(properties.key());
+			}
+		} catch (Exception ignored) {
+		}
+	}
+
+	private void stopConsumerSafely() {
+		try {
+			consumer.destroy();
+			Thread.sleep(100);
+		} catch (Exception ignored) {
+		}
+	}
+
+	@Test
+	@Order(1)
+	@DisplayName("Redis 연결이 정상적으로 설정되었다")
+	void testRedisConnection() {
+		// given
+		String testKey = "test:connection";
+		String testValue = "connected";
+
+		// when
+		redisTemplate.opsForValue().set(testKey, testValue);
+		Object result = redisTemplate.opsForValue().get(testKey);
+
+		// then
+		assertEquals(testValue, result);
+		redisTemplate.delete(testKey);
+	}
+
+	@Test
+	@Order(2)
+	@DisplayName("RedisStreamProperties가 올바르게 로드되었다")
+	void testPropertiesLoaded() {
+		// given // when // then
+		assertNotNull(properties);
+		assertEquals("test.stream", properties.key());
+		assertEquals("test.group", properties.group());
+		assertEquals("test-consumer", properties.consumerName());
+		assertTrue(properties.isCreateGroupIfMissing());
+		assertFalse(properties.isAutoStart());
+		assertEquals(10, properties.batchSize());
+		assertEquals(100, properties.pollTimeoutMs());
+	}
+
+	@Test
+	@Order(3)
+	@DisplayName("Redis Stream에 메시지를 발행할 수 있다")
+	void testPublishMessage() {
+		// given
+		TestRedisStreamEvent event = new TestRedisStreamEvent("user123");
+		RedisStreamMessage message = RedisStreamMessage.of(event);
+
+		// when
+		RecordId recordId = publisher.publish(message);
+
+		// then
+		assertNotNull(recordId);
+		assertNotNull(recordId.getValue());
+
+		Long streamLength = redisTemplate.opsForStream().size(properties.key());
+		assertEquals(1L, streamLength);
+
+		List<MapRecord<String, Object, Object>> messages =
+				redisTemplate.opsForStream().range(properties.key(), Range.unbounded());
+		assertFalse(messages.isEmpty());
+		assertThat(messages.get(0).getValue()).containsKey("payload");
+	}
+
+	@Test
+	@Order(4)
+	@DisplayName("Consumer Group을 생성할 수 있다")
+	void testCreateConsumerGroup() {
+		// given // when
+		groupManager.ensureGroup();
+
+		// then
+		StreamInfo.XInfoGroups groups = redisTemplate.opsForStream().groups(properties.key());
+		assertNotNull(groups);
+		assertTrue(groups.stream().anyMatch(g -> g.groupName().equals(properties.group())));
+	}
+
+	@Test
+	@Order(5)
+	@DisplayName("Consumer를 초기화하면 Group이 준비된다")
+	void testConsumerInitialization() {
+		// given // when
+		consumer.initialize();
+
+		// then
+		StreamInfo.XInfoGroups groups = redisTemplate.opsForStream().groups(properties.key());
+		assertNotNull(groups);
+		assertTrue(groups.stream().anyMatch(g -> g.groupName().equals(properties.group())));
+	}
+
+	@Test
+	@Order(6)
+	@DisplayName("이벤트 핸들러 레지스트리가 핸들러를 등록하고 조회할 수 있다")
+	void testEventHandlerRegistry() {
+		// given
+		CountDownLatch latch = new CountDownLatch(1);
+		AtomicReference<TestRedisStreamEvent> processedEvent = new AtomicReference<>();
+		TestRedisStreamEventHandler handler = new TestRedisStreamEventHandler(objectMapper, latch, processedEvent);
+
+		// when // then
+		assertTrue(handlerRegistry.hasHandler(RedisStreamEventType.USER_REGISTERED) ||
+				handlerRegistry.getHandler(RedisStreamEventType.USER_REGISTERED) == null);
+	}
+
+	@Test
+	@Order(7)
+	@DisplayName("메시지를 발행하고 핸들러가 처리한다")
+	void testEndToEndMessageProcessing() throws InterruptedException {
+		// given
+		CountDownLatch latch = new CountDownLatch(1);
+		AtomicReference<TestRedisStreamEvent> processedEvent = new AtomicReference<>();
+		TestRedisStreamEventHandler handler = new TestRedisStreamEventHandler(objectMapper, latch, processedEvent);
+		consumer.initialize();
+		TestRedisStreamEvent event = new TestRedisStreamEvent("user456");
+		RedisStreamMessage message = RedisStreamMessage.of(event);
+
+		// when
+		RecordId recordId = publisher.publish(message);
+
+		// then
+		assertNotNull(recordId);
+		await().atMost(Duration.ofSeconds(3)).until(() -> {
+			PendingMessagesSummary summary = redisTemplate.opsForStream()
+					.pending(properties.key(), properties.group());
+			return summary.getTotalPendingMessages() == 0;
+		});
+	}
+
+	@Test
+	@Order(8)
+	@DisplayName("여러 메시지를 순차적으로 처리할 수 있다")
+	void testMultipleMessages() {
+		// given
+		consumer.initialize();
+		int messageCount = 5;
+
+		// when
+		for (int i = 0; i < messageCount; i++) {
+			TestRedisStreamEvent event = new TestRedisStreamEvent("user" + i);
+			RedisStreamMessage message = RedisStreamMessage.of(event);
+			RecordId recordId = publisher.publish(message);
+			assertNotNull(recordId);
+		}
+
+		// then
+		await().atMost(Duration.ofSeconds(5)).until(() -> {
+			PendingMessagesSummary summary = redisTemplate.opsForStream()
+					.pending(properties.key(), properties.group());
+			return summary.getTotalPendingMessages() == 0;
+		});
+
+		Long streamLength = redisTemplate.opsForStream().size(properties.key());
+		assertEquals(messageCount, streamLength);
+	}
+
+	@Test
+	@Order(9)
+	@DisplayName("메시지 직렬화/역직렬화가 정상 작동한다")
+	void testMessageSerialization() throws Exception {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		TestRedisStreamEvent event = new TestRedisStreamEvent("serialTest");
+		RedisStreamMessage original = RedisStreamMessage.builder()
+				.id("test-id-123")
+				.type(event.type())
+				.payload(event)
+				.timestamp(now)
+				.source("test-source")
+				.build();
+
+		// when
+		String json = objectMapper.writeValueAsString(original);
+		RedisStreamMessage deserialized = objectMapper.readValue(json, RedisStreamMessage.class);
+
+		// then
+		assertNotNull(deserialized);
+		assertEquals(original.getId(), deserialized.getId());
+		assertEquals(original.getType(), deserialized.getType());
+		assertEquals(original.getSource(), deserialized.getSource());
+		assertNotNull(deserialized.getPayload());
+	}
+
+	@Test
+	@Order(10)
+	@DisplayName("처리되지 않은 메시지는 PEL에 남아있다")
+	void testPendingEntryList() {
+		// given
+		groupManager.ensureGroup();
+		TestRedisStreamEvent event = new TestRedisStreamEvent("pendingTest");
+		RedisStreamMessage message = RedisStreamMessage.of(event);
+		RecordId recordId = publisher.publish(message);
+
+		// when
+		List<MapRecord<String, Object, Object>> records = redisTemplate.opsForStream().read(
+				Consumer.from(properties.group(), "temp-consumer"),
+				StreamReadOptions.empty().count(1),
+				StreamOffset.create(properties.key(), ReadOffset.lastConsumed())
+		);
+
+		// then
+		assertFalse(records.isEmpty());
+		assertEquals(recordId.getValue(), records.get(0).getId().getValue());
+
+		PendingMessagesSummary summary = redisTemplate.opsForStream()
+				.pending(properties.key(), properties.group());
+		assertEquals(1L, summary.getTotalPendingMessages());
+	}
+
+	@Test
+	@Order(11)
+	@DisplayName("Consumer Group 정보를 조회할 수 있다")
+	void testConsumerGroupInfo() {
+		// given
+		consumer.initialize();
+		TestRedisStreamEvent event = new TestRedisStreamEvent("infoTest");
+		publisher.publish(RedisStreamMessage.of(event));
+
+		// when
+		await().atMost(Duration.ofSeconds(3)).until(() -> {
+			PendingMessagesSummary summary = redisTemplate.opsForStream()
+					.pending(properties.key(), properties.group());
+			return summary.getTotalPendingMessages() == 0;
+		});
+
+		// then
+		StreamInfo.XInfoGroups groups = redisTemplate.opsForStream().groups(properties.key());
+		StreamInfo.XInfoConsumers consumers = redisTemplate.opsForStream()
+				.consumers(properties.key(), properties.group());
+
+		assertNotNull(groups);
+		assertFalse(groups.isEmpty());
+
+		StreamInfo.XInfoGroup groupInfo = groups.stream()
+				.filter(g -> g.groupName().equals(properties.group()))
+				.findFirst()
+				.orElseThrow();
+
+		assertEquals(properties.group(), groupInfo.groupName());
+		assertNotNull(groupInfo.lastDeliveredId());
+		assertTrue(groupInfo.consumerCount() > 0);
+
+		assertNotNull(consumers);
+		assertTrue(consumers.stream().anyMatch(c -> c.consumerName().equals(properties.consumerName())));
+	}
+}

--- a/src/test/java/com/example/team6server/global/redis/RedisStreamTest.java
+++ b/src/test/java/com/example/team6server/global/redis/RedisStreamTest.java
@@ -166,8 +166,8 @@ public class RedisStreamTest extends ServiceTest {
 		TestRedisStreamEventHandler handler = new TestRedisStreamEventHandler(objectMapper, latch, processedEvent);
 
 		// when // then
-		assertTrue(handlerRegistry.hasHandler(RedisStreamEventType.USER_REGISTERED) ||
-				handlerRegistry.getHandler(RedisStreamEventType.USER_REGISTERED) == null);
+		boolean exists = handlerRegistry.hasHandler(RedisStreamEventType.USER_REGISTERED);
+		assertEquals(exists, handlerRegistry.getHandler(RedisStreamEventType.USER_REGISTERED) != null);
 	}
 
 	@Test

--- a/src/test/java/com/example/team6server/global/redis/TestRedisStreamEvent.java
+++ b/src/test/java/com/example/team6server/global/redis/TestRedisStreamEvent.java
@@ -1,0 +1,13 @@
+package com.example.team6server.global.redis;
+
+import com.example.team6server.infra.redis.stream.event.RedisStreamEvent;
+
+record TestRedisStreamEvent(
+		String data
+) implements RedisStreamEvent {
+
+	@Override
+	public String type() {
+		return "TEST_TYPE";
+	}
+}

--- a/src/test/java/com/example/team6server/global/redis/TestRedisStreamEventHandler.java
+++ b/src/test/java/com/example/team6server/global/redis/TestRedisStreamEventHandler.java
@@ -1,6 +1,5 @@
 package com.example.team6server.global.redis;
 
-import com.example.team6server.infra.redis.stream.event.RedisStreamEventType;
 import com.example.team6server.infra.redis.stream.handler.AbstractRedisStreamEventHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -20,7 +19,7 @@ class TestRedisStreamEventHandler extends AbstractRedisStreamEventHandler<TestRe
 
 	@Override
 	public String getEventType() {
-		return RedisStreamEventType.USER_REGISTERED;
+		return "TEST_TYPE";
 	}
 
 	@Override

--- a/src/test/java/com/example/team6server/global/redis/TestRedisStreamEventHandler.java
+++ b/src/test/java/com/example/team6server/global/redis/TestRedisStreamEventHandler.java
@@ -1,0 +1,36 @@
+package com.example.team6server.global.redis;
+
+import com.example.team6server.infra.redis.stream.event.RedisStreamEventType;
+import com.example.team6server.infra.redis.stream.handler.AbstractRedisStreamEventHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+class TestRedisStreamEventHandler extends AbstractRedisStreamEventHandler<TestRedisStreamEvent> {
+
+	private final CountDownLatch latch;
+	private final AtomicReference<TestRedisStreamEvent> processedEvent;
+
+	public TestRedisStreamEventHandler(ObjectMapper objectMapper, CountDownLatch latch, AtomicReference<TestRedisStreamEvent> processedEvent) {
+		super(objectMapper);
+		this.latch = latch;
+		this.processedEvent = processedEvent;
+	}
+
+	@Override
+	public String getEventType() {
+		return RedisStreamEventType.USER_REGISTERED;
+	}
+
+	@Override
+	protected Class<TestRedisStreamEvent> payloadType() {
+		return TestRedisStreamEvent.class;
+	}
+
+	@Override
+	protected void onMessage(TestRedisStreamEvent event) throws Exception {
+		processedEvent.set(event);
+		latch.countDown();
+	}
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -39,3 +39,15 @@ logging:
             redis: DEBUG
           global:
             redis: DEBUG
+
+redis:
+  stream:
+    key: test.stream
+    group: test.group
+    consumer-name: test-consumer
+    isCreateGroupIfMissing: true
+    isAutoStart: false
+    batchSize: 10
+    pollTimeoutMs: 100
+    recovery:
+      enabled: false


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #12 

### 상황
- 러닝이 끝나는 시점에 결과를 저장하고, 동시에 주간/월간 통계도 업데이트해야 합니다.
- 사용자는 바로 이 데이터를 확인해야 하므로 배치 처리는 불가능했습니다.
- 이외의 메인 트랜잭션과 분리되어 처리할 수 있는 로직을 분리하기 위한 작업을 진행했습니다.
[자세한 내용](https://www.notion.so/depromeet/redis-stream-26645b4338b380f68426f93676322131?source=copy_link)

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
### 1. Redis Stream 기반 메시징 인프라 구축
- RedisStreamPublisher: 이벤트 발행 컴포넌트
- RedisStreamConsumer: Consumer Group 기반 메시지 소비
- RedisStreamEventHandler: 이벤트 타입별 핸들러 추상화

### 2. 안정성 보장 시스템
- PEL(Pending Entry List) 기반 메시지 추적
- Recovery System: 실패한 메시지 자동 재처리
- Consumer Group: 여러 인스턴스 간 로드 밸런싱

### 3. 이벤트 처리 아키텍처
- AbstractRedisStreamEventHandler: 타입 안전한 핸들러 기반 클래스
- RedisStreamEventHandlerRegistry: 이벤트 타입별 핸들러 자동 등록

### 4. 실제 적용 (신규 유저 가입 시 slack 알림 비동기 메세징 처리)
- @heogeonho @1026hz 이 부분 확인해서, 필요시 이런 방식으로 적용해주시면 됩니다! (slack도 초대해뒀어요!)
<img width="323" height="166" alt="스크린샷 2025-09-12 22 47 10" src="https://github.com/user-attachments/assets/68cf43ca-5746-4edd-bee4-c588647b57af" />

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

### 1. **유틸리티 및 어노테이션**
- `StreamMessageDecoder`: JSON 메시지 디코딩 유틸리티
- `@RedisStreamEventListener`: 이벤트 리스너 식별 마커 어노테이션

### 2. **설정 클래스**
- `RedisConfig`: Redis 연결 및 직렬화 설정
- `RedisStreamRecoveryConfig`: 스케줄링 기반 Recovery 실행

### 3. **이벤트 모델**
- `RedisStreamEvent`: 이벤트 인터페이스 정의
- `RedisStreamEventType`: 이벤트 타입 상수 관리
- `RedisStreamMessage`: 메시지 래퍼 클래스

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

> 관련해서 노션에 자세히 정리해두었습니다. 꼭 읽어봐주세요~
> [정리 자료](https://www.notion.so/depromeet/redis-stream-26c45b4338b3808c8d68f412047f1fc5?source=copy_link)

### 1. **에러 처리 및 복구 전략**
- `RedisStreamConsumer.onMessage()`: 예외 발생시 PEL 유지 전략이 적절한지
- `RedisStreamRecovery.reprocessPending()`: Recovery 로직의 안정성
- Consumer 장애 상황에서의 메시지 손실 가능성

### 2. **성능 관련 설정값**
- `pollTimeoutMs: 2000`: 폴링 주기가 적절한지
- `minIdleMs: 300000`: Recovery 대상 선정 기준 (5분)이 적절한지
- `maxMessages: 100`: 한 번에 처리할 Recovery 메시지 수

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요
*

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#

---
## 📝 Assignee를 위한 CheckList
- [x] 배포환경에 redis 등록
- [x] application-*.yml 갱신 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 회원가입 성공 시 사용자 등록 이벤트를 Redis Stream으로 발행하고 Slack 환영 메시지 전송 자동화
  - Redis Streams 기반 게시·구독(퍼블리시/컨슈머), 이벤트 핸들러 레지스트리, 메시지 매핑 및 보류 메시지 재처리(복구) 기능 도입
  - 전역 ObjectMapper 설정 추가(JavaTimeModule, ISO-8601 날짜 직렬화)

- **Tests**
  - Redis Stream 퍼블리시/컨슈머, 보류 메시지 복구 및 엔드투엔드 통합 테스트 추가

- **Chores**
  - Redis 관련 라이브러리 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->